### PR TITLE
Add Markdown docs for each of the findings

### DIFF
--- a/jenkins/java/ql/src/BadRoleCheck.md
+++ b/jenkins/java/ql/src/BadRoleCheck.md
@@ -1,0 +1,5 @@
+A `Callable` implements `#checkRoles(RoleChecker)` without calling `RoleChecker#check` on the provided argument.
+
+This may allow malicious agent processes to execute code on the Jenkins controller, compromising security, on Jenkins before 2.319 and LTS 2.303.3.
+
+See the [method Javadoc](https://javadoc.jenkins.io/component/remoting/org/jenkinsci/remoting/RoleSensitive.html) and [developer guide for remoting callabes](https://www.jenkins.io/doc/developer/security/remoting-callables/)

--- a/jenkins/java/ql/src/CredentialsEnumeration.md
+++ b/jenkins/java/ql/src/CredentialsEnumeration.md
@@ -1,0 +1,6 @@
+This is a Stapler web method whose name indicates it provides options for a dropdown list UI element. It does not implement a permission check, but ends up calling `CredentialsProvider#lookupCredentials`.
+
+This is likely a security vulnerability, enumerating credentials IDs to users with only Overall/Read permission.
+A permission check should be added.
+
+See the [documentation on form validation](https://www.jenkins.io/doc/developer/security/form-validation/) as well as [the specific advice in the Credentials plugin consumer guide](https://github.com/jenkinsci/credentials-plugin/blob/master/docs/consumer.adoc#providing-a-ui-form-element-to-let-a-user-select-credentials).

--- a/jenkins/java/ql/src/FileFromRestOfPath.md
+++ b/jenkins/java/ql/src/FileFromRestOfPath.md
@@ -1,0 +1,1 @@
+`#getRestOfPath` and/or the file path resulting from its use needs to be carefully sanitized to not result in a path traversal vulnerability.

--- a/jenkins/java/ql/src/HasPermissionReturnIgnored.md
+++ b/jenkins/java/ql/src/HasPermissionReturnIgnored.md
@@ -1,0 +1,25 @@
+== Ignoring return value of `#hasPermission` calls
+
+This code calls `#hasPermission` without checking the return value. This call should either be `#checkPermission`, or have its return value used.
+
+If your current code looks like this:
+
+    Jenkins.get().hasPermission(Jenkins.ADMINISTER)
+
+Change it to this:
+
+    Jenkins.get().checkPermission(Jenkins.ADMINISTER)
+
+Alternatively, to get a non-default behavior (throwing an exception), depending on the context of this code, you could do something like this:
+
+In form validation (typically in methods called `#doCheckFieldname`):
+
+    if (!Jenkins.get().hasPermission(Jenkins.ADMINISTER)) {
+        return FormValidation.ok();
+    }
+
+In methods providing values for selection menus (typically methods called `#doFillFieldname`):
+
+    if (!Jenkins.get().hasPermission(Jenkins.ADMINISTER)) {
+        return new ListBoxModel();
+    }

--- a/jenkins/java/ql/src/HasPermissionReturnIgnored.ql
+++ b/jenkins/java/ql/src/HasPermissionReturnIgnored.ql
@@ -1,6 +1,6 @@
 /**
  * @name Result of hasPermission call is ignored
- * @description The result of a #hasPermission call is ignored, indicating a missing permission check: If should either be a call to #checkPermission, or the return value should not be ignored
+ * @description The result of a #hasPermission call is ignored, indicating a missing permission check: It should either be a call to #checkPermission, or the return value should not be ignored
  * @kind problem
  * @problem.severity warning
  * @precision high

--- a/jenkins/java/ql/src/PlaintextPasswordStorage.md
+++ b/jenkins/java/ql/src/PlaintextPasswordStorage.md
@@ -1,0 +1,10 @@
+A Jenkins component class that may store a password, token, or similar credentials in plain text when serialized. See the [documentation on storing secrets in Jenkins](https://www.jenkins.io/doc/developer/security/secrets/) how to properly store credentials.
+
+## False Positive Guidance
+
+This check attempts to identify fields that would result in credentials being serialized to disk based on the _field name_.
+
+* If the object is never serialized to disk (e.g., it is not directly or transitively stored as part of configuration or build data), this check can be ignored.
+* Field names can easily mislead this check. For example, `key` is interpreted as storing sensitive information, even if it's just a key/value mapping.
+
+If either is the case, simply mark this finding as a false positive.

--- a/jenkins/java/ql/src/UnsafeCalls.md
+++ b/jenkins/java/ql/src/UnsafeCalls.md
@@ -8,4 +8,4 @@ This check identified one of several methods being invoked. Jenkins plugins gene
 * `javax.net.ssl.HttpsURLConnection#setHostnameVerifier`
 * `javax.net.ssl.HttpsURLConnection#setSSLSocketFactory`
 
-See the [documentation on misc APIs](https://www.jenkins.io/doc/developer/security/misc/).
+See the [documentation on misc APIs](https://www.jenkins.io/doc/developer/security/misc/) for recommendations.

--- a/jenkins/java/ql/src/UnsafeCalls.md
+++ b/jenkins/java/ql/src/UnsafeCalls.md
@@ -1,0 +1,11 @@
+This check identified one of several methods being invoked. Jenkins plugins generally should not call any of these methods. While there may be legitimate use cases, care needs to be taken that these don't cause problems.
+
+* `java.lang.System#exit`
+* `java.lang.Runtime#exec`
+* `javax.net.ssl.SSLContext#init`
+* `javax.net.ssl.HttpsURLConnection#setDefaultSSLSocketFactory`
+* `javax.net.ssl.HttpsURLConnection#setDefaultHostnameVerifier`
+* `javax.net.ssl.HttpsURLConnection#setHostnameVerifier`
+* `javax.net.ssl.HttpsURLConnection#setSSLSocketFactory`
+
+See the [documentation on misc APIs](https://www.jenkins.io/doc/developer/security/misc/).

--- a/jenkins/java/ql/src/UnsafeClassUses.md
+++ b/jenkins/java/ql/src/UnsafeClassUses.md
@@ -1,5 +1,5 @@
 This check identified that one of the classes listed below is used. Use of these classes is potentially unsafe, usually due to bad defaults or inherent issues invoking these with user data.
-Care needs to be taken that these don't cause problems. See the [documentation on misc APIs use in Jenkins](https://www.jenkins.io/doc/developer/security/misc/).
+Care needs to be taken that use of these classes does not cause security issues. See the [documentation on misc APIs use in Jenkins](https://www.jenkins.io/doc/developer/security/misc/) for recommendations.
 
 Using these classes with user-controlled input is generally unsafe:
 

--- a/jenkins/java/ql/src/UnsafeClassUses.md
+++ b/jenkins/java/ql/src/UnsafeClassUses.md
@@ -1,0 +1,20 @@
+This check identified that one of the classes listed below is used. Use of these classes is potentially unsafe, usually due to bad defaults or inherent issues invoking these with user data.
+Care needs to be taken that these don't cause problems. See the [documentation on misc APIs use in Jenkins](https://www.jenkins.io/doc/developer/security/misc/).
+
+Using these classes with user-controlled input is generally unsafe:
+
+* `groovy.lang.GroovyShell`
+* `groovy.text.SimpleTemplateEngine`
+* `groovy.util.GroovyScriptEngine`
+* `hudson.ExpressionFactory2`
+* `hudson.util.spring.BeanBuilder`
+* `javaposse.jobdsl.dsl.DslScriptLoader`
+* `org.apache.commons.jelly.GroovyShell`
+* `org.apache.commons.jelly.Script`
+
+XML processing can easily result in XXE vulnerabilities unless specifically disabled:
+
+* `hudson.util.Digester2`
+* `javax.xml.transform.TransformerFactory`
+* `org.apache.commons.digester.Digester`
+* `org.apache.commons.digester3.Digester`

--- a/jenkins/java/ql/src/WebMethodMissingPermissionCheck.md
+++ b/jenkins/java/ql/src/WebMethodMissingPermissionCheck.md
@@ -1,7 +1,9 @@
-A Stapler web method does not perform a permission check. This can be problem if the method returns private information, or has side effects. See [the documentation](https://www.jenkins.io/doc/developer/security/form-validation/).
+This Stapler web method does not perform a permission check. This can be problem if the method returns private information, or has side effects. See [the documentation](https://www.jenkins.io/doc/developer/security/form-validation/).
 
-## False Positive Guidance
+### False Positive Guidance
 
-This check can easily identify _false positives_, i.e. safe code is marked as being unsafe. In that case, simply ignore this message after reviewing the code that it does not do anything sensitive.
+This check can easily identify _false positives_, i.e. safe code that is marked as being unsafe. In that case, simply ignore this message after confirming that the code does not return private information, or have side effects.
 
 <!-- TODO More details what is 'anything sensitive' -->
+
+Additionally, this check has a known bug: It identifies methods matching the Stapler web method naming scheme (e.g. `doWhatever`) even if they have no arguments and declare a `void` return type. [Since Jenkins 2.154 and LTS 2.138.4, these methods can no longer be invoked by Stapler](https://www.jenkins.io/doc/developer/handling-requests/actions/), so do not need a permission check. In this case, mark this finding as false positive.

--- a/jenkins/java/ql/src/WebMethodMissingPermissionCheck.md
+++ b/jenkins/java/ql/src/WebMethodMissingPermissionCheck.md
@@ -1,0 +1,7 @@
+A Stapler web method does not perform a permission check. This can be problem if the method returns private information, or has side effects. See [the documentation](https://www.jenkins.io/doc/developer/security/form-validation/).
+
+## False Positive Guidance
+
+This check can easily identify _false positives_, i.e. safe code is marked as being unsafe. In that case, simply ignore this message after reviewing the code that it does not do anything sensitive.
+
+<!-- TODO More details what is 'anything sensitive' -->

--- a/jenkins/java/ql/src/WebMethodMissingPostAnnotation.md
+++ b/jenkins/java/ql/src/WebMethodMissingPostAnnotation.md
@@ -1,0 +1,9 @@
+This Stapler web method has no verb annotation. This can be problem if the method has side effects and if so, is known as a [Cross-site request forgery (CSRF)](https://owasp.org/www-community/attacks/csrf) vulnerability. See [the documentation](https://www.jenkins.io/doc/developer/security/form-validation/).
+
+## False Positive Guidance
+
+This check can easily identify _false positives_, i.e. safe code is marked as being unsafe. In that case, simply ignore this message after reviewing the code that it does not have _side effects_.
+
+<!-- TODO More details what is 'anything sensitive' -->
+
+<!-- TODO Explain relation to the 'missing permission check' -->

--- a/jenkins/java/ql/src/WebMethodMissingPostAnnotation.md
+++ b/jenkins/java/ql/src/WebMethodMissingPostAnnotation.md
@@ -1,9 +1,11 @@
 This Stapler web method has no verb annotation. This can be problem if the method has side effects and if so, is known as a [Cross-site request forgery (CSRF)](https://owasp.org/www-community/attacks/csrf) vulnerability. See [the documentation](https://www.jenkins.io/doc/developer/security/form-validation/).
 
-## False Positive Guidance
+### False Positive Guidance
 
-This check can easily identify _false positives_, i.e. safe code is marked as being unsafe. In that case, simply ignore this message after reviewing the code that it does not have _side effects_.
+This check can easily identify _false positives_, i.e. safe code that is marked as being unsafe. In that case, simply ignore this message after confirming that the code does not have _side effects_.
 
 <!-- TODO More details what is 'anything sensitive' -->
 
 <!-- TODO Explain relation to the 'missing permission check' -->
+
+Additionally, this check has a known bug: It identifies methods matching the Stapler web method naming scheme (e.g. `doWhatever`) even if they have no arguments and declare a `void` return type. [Since Jenkins 2.154 and LTS 2.138.4, these methods can no longer be invoked by Stapler](https://www.jenkins.io/doc/developer/handling-requests/actions/), so do not need a permission check. In this case, mark this finding as false positive.


### PR DESCRIPTION
These will be displayed below each finding in place of the current plain text documentation.

## Before
<img width="1535" alt="Screenshot 2022-02-18 at 11 32 15" src="https://user-images.githubusercontent.com/1831569/154666024-2160804d-e6e8-424e-9f35-7aa996a91298.png">

## After
(Screenshots before slight reformatting, this isn't GH Flavored Markdown)
<img width="1528" alt="Screenshot 2022-02-18 at 11 32 20" src="https://user-images.githubusercontent.com/1831569/154666069-c6cbea0d-975f-4b51-a985-2c95201f8164.png">
<img width="1542" alt="Screenshot 2022-02-18 at 14 20 57" src="https://user-images.githubusercontent.com/1831569/154690378-637d5b19-bece-41cf-8e65-42ec27e7bec1.png">

