### PR TITLE
Improve summary for permission checks; format class Markdown

### DIFF
--- a/jenkins/java/ql/src/BadRoleCheck.md
+++ b/jenkins/java/ql/src/BadRoleCheck.md
@@ -2,8 +2,7 @@ This `Callable` implements `#checkRoles(RoleChecker)` without calling `RoleCheck
 
 ## Why is this a problem?
 
-This code may allow agent processes to execute code on the Jenkins controller.
-As a result it could compromise security on Jenkins before 2.319 and LTS 2.303.3.
+This code may allow agent processes to execute code on the Jenkins controller. As a result it could compromise security on Jenkins before 2.319 and LTS 2.303.3.
 
 ## Next Steps
 

--- a/jenkins/java/ql/src/UnsafeClassUses.md
+++ b/jenkins/java/ql/src/UnsafeClassUses.md
@@ -1,5 +1,4 @@
-This check identified that one of the classes listed below is used. Use of these classes is potentially unsafe, usually due to bad defaults or inherent issues invoking these with user data.
-Care needs to be taken that use of these classes does not cause security issues. See the [documentation on misc APIs use in Jenkins](https://www.jenkins.io/doc/developer/security/misc/) for recommendations.
+This check identified that one of the classes listed below is used. Use of these classes is potentially unsafe, usually due to bad defaults or inherent issues invoking these with user data. Care needs to be taken that use of these classes does not cause security issues. See the [documentation on misc APIs use in Jenkins](https://www.jenkins.io/doc/developer/security/misc/) for recommendations.
 
 Using these classes with user-controlled input is generally unsafe:
 

--- a/jenkins/java/ql/src/WebMethodMissingPermissionCheck.md
+++ b/jenkins/java/ql/src/WebMethodMissingPermissionCheck.md
@@ -2,7 +2,7 @@ This Stapler web method does not perform a permission check.
 
 ## Why is this a problem?
 
-This is problem if the method returns private information, or has side effects.
+This is problem if the method returns private information, or has side effects, as anyone with only basic access to Jenkins can access the web method directly.
 
 ## Next Steps
 
@@ -30,9 +30,7 @@ Anything a user would not usually be entitled to have access to without addition
 1. Information about the configuration of the system usually requires Overall/Manage, Overall/SystemRead, or Overall/Administer permission.
 2. Information about the configuration of a job usually requires Job/Configure or Job/ExtendedRead permission (although some information will be displayed to users with Job/Read permission -- and that information does not need further permission to access).
 
-As a rule of thumb, if a user with a given level of access can obtain the information through an intended UI or API, it's not a problem.
-It's also not a problem if a user could obtain the same information by reading the source code of the plugin (e.g. `doFill` methods providing a fixed list of combobox options).
-It's only a problem when direct browsing to URLs would reveal information they would not otherwise be able to access.
+As a rule of thumb, if a user with a given level of access can obtain the information through an intended UI or API, it's not a problem. It's also not a problem if a user could obtain the same information by reading the source code of the plugin (e.g. `doFill` methods providing a fixed list of combobox options). It's only a problem when direct browsing to URLs would reveal information they would not otherwise be able to access.
 
 ### What are side effects?
 


### PR DESCRIPTION
Besides the improved summary for missing permission checks, this just fixes sentence-per-line formatting (we don't have GH flavored Markdown in CodeQL).