### PR TITLE
Exclude prefixedCredentialsId from plaintext password check

### DIFF
--- a/jenkins/java/ql/src/PlaintextPasswordStorage.ql
+++ b/jenkins/java/ql/src/PlaintextPasswordStorage.ql
@@ -20,6 +20,8 @@ class StringField extends Field {
 
     predicate isProduction() {
         this.getCompilationUnit().getAbsolutePath().indexOf("src/main/java") != -1
+        or // support QL test sources
+        this.getCompilationUnit().getAbsolutePath().indexOf("test/query-tests") != -1
     }
 }
 
@@ -32,10 +34,11 @@ class StringCredentialField extends StringField {
         or this.getName().toLowerCase().indexOf("access") != -1
         or this.getName().toLowerCase().indexOf("key") != -1
         or this.getName().toLowerCase().indexOf("token") != -1)
-        and not (this.hasName("credentialsId")) // TODO there's something wrong with asserting indexOf = -1
+        and not (this.getName().toLowerCase().indexOf("credentialsid") != -1)
+        and not (this.getName().toLowerCase().indexOf("credentialid") != -1)
     }
 }
 
 from StringCredentialField m
 where m.fromSource() and m.isProduction()
-select m, "Variable should be reviewed whether it stored a password and is serialized to disk: " + m.getName()
+select m, "Field should be reviewed whether it stores a password and is serialized to disk: " + m.getName()

--- a/jenkins/java/ql/test/query-tests/PlaintextPasswordStorage.expected
+++ b/jenkins/java/ql/test/query-tests/PlaintextPasswordStorage.expected
@@ -1,0 +1,3 @@
+| PlaintextPasswordStorage.java:6:20:6:27 | password | Field should be reviewed whether it stores a password and is serialized to disk: password |
+| PlaintextPasswordStorage.java:16:20:16:29 | credential | Field should be reviewed whether it stores a password and is serialized to disk: credential |
+| PlaintextPasswordStorage.java:18:20:18:30 | credentials | Field should be reviewed whether it stores a password and is serialized to disk: credentials |

--- a/jenkins/java/ql/test/query-tests/PlaintextPasswordStorage.java
+++ b/jenkins/java/ql/test/query-tests/PlaintextPasswordStorage.java
@@ -1,0 +1,21 @@
+import hudson.util.Secret;
+
+public class PlaintextPasswordStorage {
+    private static String PASSWORD;
+
+    private String password;
+
+    private String credentialsId;
+
+    private String prefixedCredentialsId;
+
+    private String credentialId;
+
+    private String prefixedCredentialId;
+
+    private String credential;
+
+    private String credentials;
+
+    private Secret secretPassword;
+}

--- a/jenkins/java/ql/test/query-tests/PlaintextPasswordStorage.qlref
+++ b/jenkins/java/ql/test/query-tests/PlaintextPasswordStorage.qlref
@@ -1,0 +1,1 @@
+PlaintextPasswordStorage.ql

--- a/jenkins/java/ql/test/stubs/jenkins/hudson/util/Secret.java
+++ b/jenkins/java/ql/test/stubs/jenkins/hudson/util/Secret.java
@@ -1,0 +1,4 @@
+package hudson.util;
+
+public class Secret {
+}


### PR DESCRIPTION
Also add tests for this query and revise the inline message a bit

Closes #13.