### PR TITLE
Use markup for code snippets

### DIFF
--- a/src/HasPermissionReturnIgnored.md
+++ b/src/HasPermissionReturnIgnored.md
@@ -23,23 +23,24 @@ At a minimum, this line of code would need to be removed if there's no need for 
 ## How can I fix the code?
 
 If your current code looks like this:
-
-    Jenkins.get().hasPermission(Jenkins.ADMINISTER)
-
+```java
+Jenkins.get().hasPermission(Jenkins.ADMINISTER)
+```
 Change it to this:
-
-    Jenkins.get().checkPermission(Jenkins.ADMINISTER)
-
+```java
+Jenkins.get().checkPermission(Jenkins.ADMINISTER)
+```
 Alternatively, to get a non-default behavior (throwing an exception), depending on the context of this code, you could do something like this:
 
 In form validation (typically in methods called `#doCheckFieldname`):
-
-    if (!Jenkins.get().hasPermission(Jenkins.ADMINISTER)) {
-        return FormValidation.ok();
-    }
-
+```java
+if (!Jenkins.get().hasPermission(Jenkins.ADMINISTER)) {
+    return FormValidation.ok();
+}
+```
 In methods providing values for selection menus (typically methods called `#doFillFieldname`):
-
-    if (!Jenkins.get().hasPermission(Jenkins.ADMINISTER)) {
-        return new ListBoxModel();
-    }
+```java
+if (!Jenkins.get().hasPermission(Jenkins.ADMINISTER)) {
+    return new ListBoxModel();
+}
+```

--- a/src/WebMethodMissingPermissionCheck.md
+++ b/src/WebMethodMissingPermissionCheck.md
@@ -59,17 +59,16 @@ This check identifies methods matching the Stapler web method naming scheme (e.g
 You generally want to add a permission check to the method. Broadly speaking, there are two strategies:
 
 Calling `#checkPermission` will throw an exception if the current user does not have the specified permission:
-
-    Jenkins.get().checkPermission(Jenkins.ADMINISTER)
-
+```java
+Jenkins.get().checkPermission(Jenkins.ADMINISTER)
+```
 Calling `#hasPermission` will return whether the current user has the specified permission and can be used to customize the response, like a form validation not performing actions with side effects:
-
-
-    public FormValidation doCheckUrl(@QueryParameter String value) {
-        if (!Jenkins.get().hasPermission(Jenkins.ADMINISTER)) {
-            return FormValidation.ok();
-        }
-        // Ensure 'value' is a valid URL actually pointing to the service being configured
+```java
+public FormValidation doCheckUrl(@QueryParameter String value) {
+    if (!Jenkins.get().hasPermission(Jenkins.ADMINISTER)) {
+        return FormValidation.ok();
     }
-
+    // Ensure 'value' is a valid URL actually pointing to the service being configured
+}
+```
 For further information, see [the documentation on safely implementing form validation](https://www.jenkins.io/doc/developer/security/form-validation/). Despite the name, it applies to more than just form validation.


### PR DESCRIPTION
We can make use of GH's Java language support for the the code snippets, given the security scan tab supports GH flavored markdown.

A minor change to improve readability to use the layout you are probably already used to from other occasions on GH.