### PR TITLE
Update from 2.15.1/Java 0.8.1 to 2.16.4/Java 0.8.10

### DIFF
--- a/lib/codeql-pack.lock.yml
+++ b/lib/codeql-pack.lock.yml
@@ -2,19 +2,23 @@
 lockVersion: 1.0.0
 dependencies:
   codeql/dataflow:
-    version: 0.1.1
+    version: 0.2.1
   codeql/java-all:
-    version: 0.8.1
+    version: 0.8.10
   codeql/mad:
-    version: 0.2.1
+    version: 0.2.10
+  codeql/rangeanalysis:
+    version: 0.0.9
   codeql/regex:
-    version: 0.2.1
+    version: 0.2.10
   codeql/ssa:
-    version: 0.2.1
+    version: 0.2.10
+  codeql/threat-models:
+    version: 0.0.9
   codeql/tutorial:
-    version: 0.2.1
+    version: 0.2.10
   codeql/typetracking:
-    version: 0.2.1
+    version: 0.2.10
   codeql/util:
-    version: 0.2.1
+    version: 0.2.10
 compiled: false

--- a/lib/qlpack.yml
+++ b/lib/qlpack.yml
@@ -3,4 +3,4 @@ library: true
 name: jenkins-infra/jenkins-codeql-lib
 version: 0.0.2-dev
 dependencies:
-  codeql/java-all: 0.8.1 # https://github.com/github/codeql/blob/main/java/ql/src/CHANGELOG.md
+  codeql/java-all: 0.8.10

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+CODEQL_VERSION=2.16.4
+
 set -o errexit
 set -o nounset
 set -o pipefail
@@ -15,7 +17,7 @@ echo "Using temp dir $TMPDIR ..." >&2
 cd "$TMPDIR"
 
 echo "Downloading CodeQL CLI ..." >&2
-curl --location --silent --fail --output codeql.zip "https://github.com/github/codeql-cli-binaries/releases/download/v2.15.1/codeql-${OS}.zip"
+curl --location --silent --fail --output codeql.zip "https://github.com/github/codeql-cli-binaries/releases/download/v$CODEQL_VERSION/codeql-${OS}.zip"
 
 echo "Extracting CodeQL CLI ..." >&2
 unzip -q codeql.zip # Into codeql/ directory

--- a/src/HasPermissionReturnIgnored.ql
+++ b/src/HasPermissionReturnIgnored.ql
@@ -11,7 +11,7 @@
 
 import java
 
-from MethodAccess unchecked, Method m
+from MethodCall unchecked, Method m
 where unchecked.getMethod() = m and m.hasName("hasPermission")
   and unchecked.getParent() instanceof ExprStmt
 select unchecked, "The result of the call is ignored"

--- a/src/codeql-pack.lock.yml
+++ b/src/codeql-pack.lock.yml
@@ -2,19 +2,23 @@
 lockVersion: 1.0.0
 dependencies:
   codeql/dataflow:
-    version: 0.1.1
+    version: 0.2.1
   codeql/java-all:
-    version: 0.8.1
+    version: 0.8.10
   codeql/mad:
-    version: 0.2.1
+    version: 0.2.10
+  codeql/rangeanalysis:
+    version: 0.0.9
   codeql/regex:
-    version: 0.2.1
+    version: 0.2.10
   codeql/ssa:
-    version: 0.2.1
+    version: 0.2.10
+  codeql/threat-models:
+    version: 0.0.9
   codeql/tutorial:
-    version: 0.2.1
+    version: 0.2.10
   codeql/typetracking:
-    version: 0.2.1
+    version: 0.2.10
   codeql/util:
-    version: 0.2.1
+    version: 0.2.10
 compiled: false

--- a/src/qlpack.yml
+++ b/src/qlpack.yml
@@ -3,5 +3,5 @@ library: false
 name: jenkins-infra/jenkins-codeql
 version: 0.0.2-dev
 dependencies:
-  codeql/java-all: 0.8.1 # https://github.com/github/codeql/blob/main/java/ql/src/CHANGELOG.md
+  codeql/java-all: 0.8.10
   jenkins-infra/jenkins-codeql-lib: '*'

--- a/test/codeql-pack.lock.yml
+++ b/test/codeql-pack.lock.yml
@@ -2,19 +2,23 @@
 lockVersion: 1.0.0
 dependencies:
   codeql/dataflow:
-    version: 0.1.1
+    version: 0.2.1
   codeql/java-all:
-    version: 0.8.1
+    version: 0.8.10
   codeql/mad:
-    version: 0.2.1
+    version: 0.2.10
+  codeql/rangeanalysis:
+    version: 0.0.9
   codeql/regex:
-    version: 0.2.1
+    version: 0.2.10
   codeql/ssa:
-    version: 0.2.1
+    version: 0.2.10
+  codeql/threat-models:
+    version: 0.0.9
   codeql/tutorial:
-    version: 0.2.1
+    version: 0.2.10
   codeql/typetracking:
-    version: 0.2.1
+    version: 0.2.10
   codeql/util:
-    version: 0.2.1
+    version: 0.2.10
 compiled: false

--- a/test/qlpack.yml
+++ b/test/qlpack.yml
@@ -1,7 +1,7 @@
 name: jenkins-infra/java-tests
 groups: [java, test]
 dependencies:
-  codeql/java-all: 0.8.1 # https://github.com/github/codeql/blob/main/java/ql/src/CHANGELOG.md
+  codeql/java-all: 0.8.10
   jenkins-infra/jenkins-codeql-lib: "*"
   jenkins-infra/jenkins-codeql: "*"
 extractor: java


### PR DESCRIPTION
This small dependency update was a bit of a nightmare.

Instructions I left for myself in this repo were mostly fine (note https://github.com/jenkins-infra/jenkins-codeql/pull/35), except that https://github.com/github/codeql/releases/tag/codeql-cli%2Fv2.16.4 is not (yet) on `main` so the links in the docs show 0.8.9 as the latest Java lib on `main`. No clue how upstream managed those branches, for now I removed some comments and let the steps in https://github.com/jenkins-infra/jenkins-codeql/pull/35 take care of that in the future.

Worse were the deprecations that show up as test failures.

* `MethodAccess` to `MethodCall` was easy to find: https://github.com/github/codeql/blob/9aefdca7a7d7866b12e171df63f6666a253130c9/java/ql/lib/semmle/code/java/Expr.qll#L2109-L2110
* The other was more of a mess. I was unable to find the specific changelog for it, and https://github.com/github/codeql/pull/14983 only provided minimal information. Ultimately I ended up looking at what the [documentation](https://codeql.github.com/docs/codeql-language-guides/analyzing-data-flow-in-java/#analyzing-data-flow-in-java) says is the new way to do things and adapted what I had until it passed the test.