### PR TITLE
Add license metadata to QL packs

### DIFF
--- a/lib/qlpack.yml
+++ b/lib/qlpack.yml
@@ -2,5 +2,6 @@
 library: true
 name: jenkins-infra/jenkins-codeql-lib
 version: 0.0.2-dev
+license: MIT
 dependencies:
   codeql/java-all: 0.8.1 # https://github.com/github/codeql/blob/main/java/ql/src/CHANGELOG.md

--- a/src/qlpack.yml
+++ b/src/qlpack.yml
@@ -2,6 +2,7 @@
 library: false
 name: jenkins-infra/jenkins-codeql
 version: 0.0.2-dev
+license: MIT
 dependencies:
   codeql/java-all: 0.8.1 # https://github.com/github/codeql/blob/main/java/ql/src/CHANGELOG.md
   jenkins-infra/jenkins-codeql-lib: '*'

--- a/test/qlpack.yml
+++ b/test/qlpack.yml
@@ -1,5 +1,6 @@
 name: jenkins-infra/java-tests
 groups: [java, test]
+license: MIT
 dependencies:
   codeql/java-all: 0.8.1 # https://github.com/github/codeql/blob/main/java/ql/src/CHANGELOG.md
   jenkins-infra/jenkins-codeql-lib: "*"


### PR DESCRIPTION
https://docs.github.com/en/code-security/codeql-cli/using-the-advanced-functionality-of-the-codeql-cli/publishing-and-using-codeql-packs#license