### PR TITLE
Fix bad copy & paste in suppression instructions

### DIFF
--- a/src/BadRoleCheck.md
+++ b/src/BadRoleCheck.md
@@ -12,7 +12,7 @@ This code may allow agent processes to execute code on the Jenkins controller. A
 2. Determine whether this finding is a false positive (see guidance below). This is an automated scan result, so that's always a possibility. In general, the rules err on the side of caution, so false positives are pretty common. If it is a false positive, do either of the following, and you're done!
     * [Mark it as such on the GitHub UI](https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/managing-code-scanning-alerts-for-your-repository#dismissing--alerts)
     * Suppress the finding through a simple code change:
-      Annotate the code location with `@SuppressWarnings("lgtm[jenkins/credentials-fill-without-permission-check]")` or add this comment just before: `// lgtm[jenkins/credentials-fill-without-permission-check]`.
+      Annotate the code location with `@SuppressWarnings("lgtm[jenkins/callable-without-role-check]")` or add this comment just before: `// lgtm[jenkins/callable-without-role-check]`.
       This is supported when using the Jenkins Security Scan workflow and in other CodeQL scans that support suppressing findings this way.
 3. If this is a true positive finding, use the documentation below to resolve it.
 

--- a/src/FileFromRestOfPath.md
+++ b/src/FileFromRestOfPath.md
@@ -12,7 +12,7 @@ If your code is modifying or reading a file as specified in the URL, users able 
 2. Determine whether this finding is a false positive (see guidance below). This is an automated scan result, so that's always a possibility. In general, the rules err on the side of caution, so false positives are pretty common. If it is a false positive, do either of the following, and you're done!
     * [Mark it as such on the GitHub UI](https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/managing-code-scanning-alerts-for-your-repository#dismissing--alerts)
     * Suppress the finding through a simple code change:
-      Annotate the code location with `@SuppressWarnings("lgtm[jenkins/credentials-fill-without-permission-check]")` or add this comment just before: `// lgtm[jenkins/credentials-fill-without-permission-check]`.
+      Annotate the code location with `@SuppressWarnings("lgtm[jenkins/file-from-rest-of-path]")` or add this comment just before: `// lgtm[jenkins/file-from-rest-of-path]`.
       This is supported when using the Jenkins Security Scan workflow and in other CodeQL scans that support suppressing findings this way.
 3. If this is a true positive finding, use the documentation below to resolve it.
 

--- a/src/HasPermissionReturnIgnored.md
+++ b/src/HasPermissionReturnIgnored.md
@@ -12,7 +12,7 @@ This is indicative of a bug: Code intended to ensure the user accessing some fun
 2. Determine whether this finding is a false positive (see guidance below). This is an automated scan result, so that's always a possibility. In general, the rules err on the side of caution, so false positives are pretty common. If it is a false positive, do either of the following, and you're done!
     * [Mark it as such on the GitHub UI](https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/managing-code-scanning-alerts-for-your-repository#dismissing--alerts)
     * Suppress the finding through a simple code change:
-      Annotate the code location with `@SuppressWarnings("lgtm[jenkins/credentials-fill-without-permission-check]")` or add this comment just before: `// lgtm[jenkins/credentials-fill-without-permission-check]`.
+      Annotate the code location with `@SuppressWarnings("lgtm[jenkins/has-permission-return-value-ignored]")` or add this comment just before: `// lgtm[jenkins/has-permission-return-value-ignored]`.
       This is supported when using the Jenkins Security Scan workflow and in other CodeQL scans that support suppressing findings this way.
 3. If this is a true positive finding, use the documentation below to resolve it.
 

--- a/src/PlaintextPasswordStorage.md
+++ b/src/PlaintextPasswordStorage.md
@@ -12,7 +12,7 @@ Jenkins stores lots of credentials to other systems, like agent cloud providers,
 2. Determine whether this finding is a false positive (see guidance below). This is an automated scan result, so that's always a possibility. In general, the rules err on the side of caution, so false positives are pretty common. If it is a false positive, do either of the following, and you're done!
     * [Mark it as such on the GitHub UI](https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/managing-code-scanning-alerts-for-your-repository#dismissing--alerts)
     * Suppress the finding through a simple code change:
-      Annotate the code location with `@SuppressWarnings("lgtm[jenkins/credentials-fill-without-permission-check]")` or add this comment just before: `// lgtm[jenkins/credentials-fill-without-permission-check]`.
+      Annotate the code location with `@SuppressWarnings("lgtm[jenkins/plaintext-storage]")` or add this comment just before: `// lgtm[jenkins/plaintext-storage]`.
       This is supported when using the Jenkins Security Scan workflow and in other CodeQL scans that support suppressing findings this way.
 3. If this is a true positive finding, use the documentation below to resolve it.
 

--- a/src/UnsafeCalls.md
+++ b/src/UnsafeCalls.md
@@ -12,7 +12,7 @@ Incorrect use of APIs can result in a security vulnerability.
 2. Determine whether this finding is a false positive (see guidance below). This is an automated scan result, so that's always a possibility. In general, the rules err on the side of caution, so false positives are pretty common. If it is a false positive, do either of the following, and you're done!
     * [Mark it as such on the GitHub UI](https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/managing-code-scanning-alerts-for-your-repository#dismissing--alerts)
     * Suppress the finding through a simple code change:
-      Annotate the code location with `@SuppressWarnings("lgtm[jenkins/credentials-fill-without-permission-check]")` or add this comment just before: `// lgtm[jenkins/credentials-fill-without-permission-check]`.
+      Annotate the code location with `@SuppressWarnings("lgtm[jenkins/unsafe-calls]")` or add this comment just before: `// lgtm[jenkins/unsafe-calls]`.
       This is supported when using the Jenkins Security Scan workflow and in other CodeQL scans that support suppressing findings this way.
 3. If this is a true positive finding, use the documentation below to resolve it.
 

--- a/src/UnsafeClassUses.md
+++ b/src/UnsafeClassUses.md
@@ -12,7 +12,7 @@ Incorrect use of APIs can result in a security vulnerability.
 2. Determine whether this finding is a false positive (see guidance below). This is an automated scan result, so that's always a possibility. In general, the rules err on the side of caution, so false positives are pretty common. If it is a false positive, do either of the following, and you're done!
     * [Mark it as such on the GitHub UI](https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/managing-code-scanning-alerts-for-your-repository#dismissing--alerts)
     * Suppress the finding through a simple code change:
-      Annotate the code location with `@SuppressWarnings("lgtm[jenkins/credentials-fill-without-permission-check]")` or add this comment just before: `// lgtm[jenkins/credentials-fill-without-permission-check]`.
+      Annotate the code location with `@SuppressWarnings("lgtm[jenkins/unsafe-classes]")` or add this comment just before: `// lgtm[jenkins/unsafe-classes]`.
       This is supported when using the Jenkins Security Scan workflow and in other CodeQL scans that support suppressing findings this way.
 3. If this is a true positive finding, use the documentation below to resolve it.
 

--- a/src/WebMethodMissingPermissionCheck.md
+++ b/src/WebMethodMissingPermissionCheck.md
@@ -12,7 +12,7 @@ This is problem if the method returns private information, or has side effects, 
 2. Determine whether this finding is a false positive (see guidance below). This is an automated scan result, so that's always a possibility. In general, the rules err on the side of caution, so false positives are pretty common. If it is a false positive, do either of the following, and you're done!
     * [Mark it as such on the GitHub UI](https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/managing-code-scanning-alerts-for-your-repository#dismissing--alerts)
     * Suppress the finding through a simple code change:
-      Annotate the code location with `@SuppressWarnings("lgtm[jenkins/credentials-fill-without-permission-check]")` or add this comment just before: `// lgtm[jenkins/credentials-fill-without-permission-check]`.
+      Annotate the code location with `@SuppressWarnings("lgtm[jenkins/no-permission-check]")` or add this comment just before: `// lgtm[jenkins/no-permission-check]`.
       This is supported when using the Jenkins Security Scan workflow and in other CodeQL scans that support suppressing findings this way.
 3. If this is a true positive finding, use the documentation below to resolve it.
 

--- a/src/WebMethodMissingPostAnnotation.md
+++ b/src/WebMethodMissingPostAnnotation.md
@@ -12,7 +12,7 @@ This is problem if the method has side effects, as legitimate Jenkins users' bro
 2. Determine whether this finding is a false positive (see guidance below). This is an automated scan result, so that's always a possibility. In general, the rules err on the side of caution, so false positives are pretty common. If it is a false positive, do either of the following, and you're done!
     * [Mark it as such on the GitHub UI](https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/managing-code-scanning-alerts-for-your-repository#dismissing--alerts)
     * Suppress the finding through a simple code change:
-      Annotate the code location with `@SuppressWarnings("lgtm[jenkins/credentials-fill-without-permission-check]")` or add this comment just before: `// lgtm[jenkins/credentials-fill-without-permission-check]`.
+      Annotate the code location with `@SuppressWarnings("lgtm[jenkins/csrf]")` or add this comment just before: `// lgtm[jenkins/csrf]`.
       This is supported when using the Jenkins Security Scan workflow and in other CodeQL scans that support suppressing findings this way.
 3. If this is a true positive finding, use the documentation below to resolve it.
 


### PR DESCRIPTION
https://github.com/jenkins-infra/jenkins-codeql/pull/34 improperly copied & pasted instructions with finding-specific customized content (the ID for suppression) between Markdown files.